### PR TITLE
refactor: Enables testpackage and nlreturn linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,9 +74,7 @@ linters-settings:
 linters:
   enable-all: true
   disable:
-    - testpackage # TODO enable
-    - goerr113 # TODO enable
-    - nlreturn # TODO enable
+    - goerr113
 
 issues:
   exclude-use-default: false

--- a/component/storage/couchdb/store.go
+++ b/component/storage/couchdb/store.go
@@ -238,6 +238,7 @@ func (c *StoreCouchDB) put(k string, value []byte) error {
 
 func isJSON(textToCheck []byte) bool {
 	var js struct{}
+
 	return json.Unmarshal(textToCheck, &js) == nil
 }
 
@@ -245,6 +246,7 @@ func isJSON(textToCheck []byte) bool {
 // We want to do it all in one step, hence this manual stuff below.
 func wrapTextAsCouchDBAttachment(textToWrap []byte) []byte {
 	encodedTextToWrap := base64.StdEncoding.EncodeToString(textToWrap)
+
 	return []byte(`{"_attachments": {"data": {"data": "` + encodedTextToWrap + `", "content_type": "text/plain"}}}`)
 }
 
@@ -388,6 +390,7 @@ func (i *couchDBResultsIterator) Key() []byte {
 		v, err := strconv.Unquote(key)
 		if err != nil {
 			i.err = err
+
 			return nil
 		}
 
@@ -403,6 +406,7 @@ func (i *couchDBResultsIterator) Value() []byte {
 
 	if err := i.resultRows.ScanDoc(&rawDoc); err != nil {
 		i.err = err
+
 		return nil
 	}
 

--- a/component/storage/mysql/store.go
+++ b/component/storage/mysql/store.go
@@ -304,6 +304,7 @@ func (i *sqlDBResultsIterator) Key() []byte {
 	err := i.resultRows.Scan(&i.result.key, &i.result.value)
 	if err != nil {
 		i.err = err
+
 		return nil
 	}
 
@@ -315,6 +316,7 @@ func (i *sqlDBResultsIterator) Value() []byte {
 	err := i.resultRows.Scan(&i.result.key, &i.result.value)
 	if err != nil {
 		i.err = err
+
 		return nil
 	}
 

--- a/scripts/check_unit.sh
+++ b/scripts/check_unit.sh
@@ -19,7 +19,6 @@ if [ -z "$unit_tests_path" ]; then
 fi
 
 coverage_path="$(pwd)/coverage.txt"
-rm -f "$coverage_path"
 
 function clean ()
 {
@@ -37,14 +36,7 @@ do
       continue
   fi
   go test -count=1 -race -coverprofile=profile.out -covermode=atomic ./... -timeout=10m
-  if [ -f "$coverage_path" ]; then
-    res=$(grep -v "mode: atomic" profile.out || true )
-    if [ -n "$res" ]; then
-        echo "$res" >> "$coverage_path"
-    fi
-  else
     cat profile.out  >> "$coverage_path"
-  fi
   clean
   popd  > /dev/null
 done


### PR DESCRIPTION
This PR enables the following linters:
* testpackage
* nlreturn

Closes #12 

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>