### PR TITLE
fix: Load genesis files in trustbloc vdr initialization

### DIFF
--- a/component/vdr/trustbloc/vdr.go
+++ b/component/vdr/trustbloc/vdr.go
@@ -594,7 +594,7 @@ func (v *VDRI) Read(did string, opts ...vdrapi.ResolveOption) (*docdid.DocResolu
 		domain = v.domain
 	}
 
-	if v.enableSignatureVerification {
+	if v.enableSignatureVerification || v.useUpdateValidation {
 		if _, ok := v.validatedConsortium[domain]; !ok {
 			_, err := v.ValidateConsortium(domain)
 			if err != nil {
@@ -630,7 +630,7 @@ func (v *VDRI) Read(did string, opts ...vdrapi.ResolveOption) (*docdid.DocResolu
 		}
 
 		if docResolution != nil && !bytes.Equal(docBytes, respBytes) {
-			log.Debugf("mismatch in document contents for did %s. Doc 1: %s, Doc 2: %s",
+			log.Warnf("mismatch in document contents for did %s. Doc 1: %s, Doc 2: %s",
 				did, string(docBytes), string(respBytes))
 		}
 

--- a/component/vdr/trustbloc/vdr_test.go
+++ b/component/vdr/trustbloc/vdr_test.go
@@ -102,19 +102,22 @@ const validDoc = `{
 
 func TestVDRI_Accept(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 		require.True(t, v.Accept(DIDMethod))
 	})
 
 	t.Run("test return false", func(t *testing.T) {
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 		require.False(t, v.Accept("bloc1"))
 	})
 }
 
 func TestVDRI_Create(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		v.endpointService = &mockendpoint.MockEndpointService{
 			GetEndpointsFunc: func(domain string) (endpoints []*models.Endpoint, err error) {
@@ -165,7 +168,8 @@ func TestVDRI_Create(t *testing.T) {
 	})
 
 	t.Run("test update public key opt is empty", func(t *testing.T) {
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		v.endpointService = &mockendpoint.MockEndpointService{
 			GetEndpointsFunc: func(domain string) (endpoints []*models.Endpoint, err error) {
@@ -204,7 +208,8 @@ func TestVDRI_Create(t *testing.T) {
 	})
 
 	t.Run("test recovery public key opt is empty", func(t *testing.T) {
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		v.endpointService = &mockendpoint.MockEndpointService{
 			GetEndpointsFunc: func(domain string) (endpoints []*models.Endpoint, err error) {
@@ -243,7 +248,8 @@ func TestVDRI_Create(t *testing.T) {
 	})
 
 	t.Run("test error from get endpoints", func(t *testing.T) {
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		v.endpointService = &mockendpoint.MockEndpointService{
 			GetEndpointsFunc: func(domain string) (endpoints []*models.Endpoint, err error) {
@@ -259,13 +265,14 @@ func TestVDRI_Create(t *testing.T) {
 
 		v.sidetreeClient = &mockSidetreeClient{createDIDValue: &did.DocResolution{DIDDocument: &did.Doc{ID: "did"}}}
 
-		_, err := v.Create(nil, &did.Doc{})
+		_, err = v.Create(nil, &did.Doc{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to get endpoints")
 	})
 
 	t.Run("test error from get sidetree config", func(t *testing.T) {
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		v.endpointService = &mockendpoint.MockEndpointService{
 			GetEndpointsFunc: func(domain string) (endpoints []*models.Endpoint, err error) {
@@ -281,7 +288,7 @@ func TestVDRI_Create(t *testing.T) {
 
 		v.sidetreeClient = &mockSidetreeClient{createDIDValue: &did.DocResolution{DIDDocument: &did.Doc{ID: "did"}}}
 
-		_, err := v.Create(nil, &did.Doc{})
+		_, err = v.Create(nil, &did.Doc{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to get sidetree config")
 	})
@@ -296,7 +303,8 @@ func TestVDRI_Deactivate(t *testing.T) {
 		}))
 		defer cServ.Close()
 
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		v.sidetreeClient = &mockSidetreeClient{}
 
@@ -306,12 +314,13 @@ func TestVDRI_Deactivate(t *testing.T) {
 			},
 		}
 
-		err := v.Deactivate("did:ex:123", vdrapi.WithOption(EndpointsOpt, []string{cServ.URL}))
+		err = v.Deactivate("did:ex:123", vdrapi.WithOption(EndpointsOpt, []string{cServ.URL}))
 		require.NoError(t, err)
 	})
 
 	t.Run("test error from get endpoints", func(t *testing.T) {
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		v.endpointService = &mockendpoint.MockEndpointService{
 			GetEndpointsFunc: func(domain string) (endpoints []*models.Endpoint, err error) {
@@ -327,7 +336,7 @@ func TestVDRI_Deactivate(t *testing.T) {
 
 		v.sidetreeClient = &mockSidetreeClient{}
 
-		err := v.Deactivate("")
+		err = v.Deactivate("")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to get endpoints")
 	})
@@ -338,7 +347,8 @@ func TestVDRI_Deactivate(t *testing.T) {
 		}))
 		defer cServ.Close()
 
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		v.endpointService = &mockendpoint.MockEndpointService{
 			GetEndpointsFunc: func(domain string) (endpoints []*models.Endpoint, err error) {
@@ -348,7 +358,7 @@ func TestVDRI_Deactivate(t *testing.T) {
 
 		v.sidetreeClient = &mockSidetreeClient{}
 
-		err := v.Deactivate("")
+		err = v.Deactivate("")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to resolve did")
 	})
@@ -363,7 +373,8 @@ func TestVDRI_Update(t *testing.T) {
 		}))
 		defer cServ.Close()
 
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		v.configService = &mockconfig.MockConfigService{
 			GetSidetreeConfigFunc: func(s string) (*models.SidetreeConfig, error) {
@@ -394,7 +405,8 @@ func TestVDRI_Update(t *testing.T) {
 	})
 
 	t.Run("test error from get endpoints", func(t *testing.T) {
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		v.endpointService = &mockendpoint.MockEndpointService{
 			GetEndpointsFunc: func(domain string) (endpoints []*models.Endpoint, err error) {
@@ -410,13 +422,14 @@ func TestVDRI_Update(t *testing.T) {
 
 		v.sidetreeClient = &mockSidetreeClient{createDIDValue: &did.DocResolution{DIDDocument: &did.Doc{ID: "did"}}}
 
-		err := v.Update(&did.Doc{})
+		err = v.Update(&did.Doc{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to get endpoints")
 	})
 
 	t.Run("test error from get sidetree config", func(t *testing.T) {
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		v.endpointService = &mockendpoint.MockEndpointService{
 			GetEndpointsFunc: func(domain string) (endpoints []*models.Endpoint, err error) {
@@ -432,7 +445,7 @@ func TestVDRI_Update(t *testing.T) {
 
 		v.sidetreeClient = &mockSidetreeClient{createDIDValue: &did.DocResolution{DIDDocument: &did.Doc{ID: "did"}}}
 
-		err := v.Update(&did.Doc{})
+		err = v.Update(&did.Doc{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to get sidetree config")
 	})
@@ -443,7 +456,8 @@ func TestVDRI_Update(t *testing.T) {
 		}))
 		defer cServ.Close()
 
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		v.endpointService = &mockendpoint.MockEndpointService{
 			GetEndpointsFunc: func(domain string) (endpoints []*models.Endpoint, err error) {
@@ -459,7 +473,7 @@ func TestVDRI_Update(t *testing.T) {
 
 		v.sidetreeClient = &mockSidetreeClient{createDIDValue: &did.DocResolution{DIDDocument: &did.Doc{ID: "did"}}}
 
-		err := v.Update(&did.Doc{})
+		err = v.Update(&did.Doc{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to resolve did")
 	})
@@ -474,7 +488,8 @@ func TestVDRI_Recover(t *testing.T) {
 		}))
 		defer cServ.Close()
 
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		v.configService = &mockconfig.MockConfigService{
 			GetSidetreeConfigFunc: func(s string) (*models.SidetreeConfig, error) {
@@ -513,7 +528,8 @@ func TestVDRI_Recover(t *testing.T) {
 		}))
 		defer cServ.Close()
 
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		v.configService = &mockconfig.MockConfigService{
 			GetSidetreeConfigFunc: func(s string) (*models.SidetreeConfig, error) {
@@ -527,7 +543,7 @@ func TestVDRI_Recover(t *testing.T) {
 
 		verAuthentication := did.NewReferencedVerification(&did.VerificationMethod{ID: "id"}, did.Authentication)
 
-		err := v.Update(&did.Doc{
+		err = v.Update(&did.Doc{
 			Service:        []did.Service{{ID: "svc"}},
 			Authentication: []did.Verification{*verAuthentication},
 		},
@@ -669,9 +685,10 @@ func signedStakeholderFileData(t *testing.T, stakeholder *models.Stakeholder, ke
 
 func TestVDRI_Read(t *testing.T) {
 	t.Run("test error from get http vdri for resolver url", func(t *testing.T) {
-		v := New(&mockKeyRetriever{}, WithResolverURL("url"))
+		v, err := New(&mockKeyRetriever{}, WithResolverURL("url"))
+		require.NoError(t, err)
 
-		_, err := v.getHTTPVDRI("")
+		_, err = v.getHTTPVDRI("")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "empty url")
 
@@ -686,7 +703,8 @@ func TestVDRI_Read(t *testing.T) {
 	})
 
 	t.Run("test error from http vdri build for resolver url", func(t *testing.T) {
-		v := New(&mockKeyRetriever{}, WithResolverURL("url"))
+		v, err := New(&mockKeyRetriever{}, WithResolverURL("url"))
+		require.NoError(t, err)
 
 		v.getHTTPVDRI = httpVdriFunc(nil, fmt.Errorf("read error"))
 
@@ -697,7 +715,8 @@ func TestVDRI_Read(t *testing.T) {
 	})
 
 	t.Run("test success for resolver url", func(t *testing.T) {
-		v := New(&mockKeyRetriever{}, WithResolverURL("url"))
+		v, err := New(&mockKeyRetriever{}, WithResolverURL("url"))
+		require.NoError(t, err)
 
 		v.getHTTPVDRI = httpVdriFunc(&did.DocResolution{DIDDocument: &did.Doc{ID: "did"}}, nil)
 
@@ -707,7 +726,8 @@ func TestVDRI_Read(t *testing.T) {
 	})
 
 	t.Run("test error parsing did", func(t *testing.T) {
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		v.getHTTPVDRI = func(url string) (v vdri, err error) {
 			return nil, nil
@@ -720,7 +740,8 @@ func TestVDRI_Read(t *testing.T) {
 	})
 
 	t.Run("test error from get endpoints", func(t *testing.T) {
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		v.endpointService = &mockendpoint.MockEndpointService{
 			GetEndpointsFunc: func(domain string) (endpoints []*models.Endpoint, err error) {
@@ -759,7 +780,8 @@ func TestVDRI_Read(t *testing.T) {
 	})
 
 	t.Run("test error from get http vdri", func(t *testing.T) {
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		v.endpointService = &mockendpoint.MockEndpointService{
 			GetEndpointsFunc: func(domain string) (endpoints []*models.Endpoint, err error) {
@@ -780,7 +802,8 @@ func TestVDRI_Read(t *testing.T) {
 	})
 
 	t.Run("test error from http vdri read", func(t *testing.T) {
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		v.endpointService = &mockendpoint.MockEndpointService{
 			GetEndpointsFunc: func(domain string) (endpoints []*models.Endpoint, err error) {
@@ -832,10 +855,11 @@ func TestVDRI_Read(t *testing.T) {
 			Previous: "",
 		}, sigKey)
 
-		v := New(&mockKeyRetriever{},
+		v, err := New(&mockKeyRetriever{},
 			WithDomain("domain"),
 			UseGenesisFile("testnet", "testnet", []byte(cfd.JWS.FullSerialize())),
 		)
+		require.NoError(t, err)
 
 		v.endpointService = &mockendpoint.MockEndpointService{
 			GetEndpointsFunc: func(domain string) (endpoints []*models.Endpoint, err error) {
@@ -871,18 +895,14 @@ func TestVDRI_loadGenesisFiles(t *testing.T) {
 		confFile, err := signConfig(conf, []jose.SigningKey{*sigKey})
 		require.NoError(t, err)
 
-		v := New(&mockKeyRetriever{}, UseGenesisFile("url", "domain", []byte(confFile)))
-
-		err = v.loadGenesisFiles()
+		_, err = New(&mockKeyRetriever{}, UseGenesisFile("url", "domain", []byte(confFile)))
 		require.NoError(t, err)
 	})
 
 	t.Run("fail: bad consortium data", func(t *testing.T) {
 		confFile := "this is not a consortium config jws"
 
-		v := New(&mockKeyRetriever{}, UseGenesisFile("url", "domain", []byte(confFile)))
-
-		err := v.loadGenesisFiles()
+		_, err := New(&mockKeyRetriever{}, UseGenesisFile("url", "domain", []byte(confFile)))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "error loading consortium genesis config")
 	})
@@ -890,12 +910,9 @@ func TestVDRI_loadGenesisFiles(t *testing.T) {
 	t.Run("fail: try to read using a vdri with a bad genesis file", func(t *testing.T) {
 		confFile := "this is not a consortium config jws"
 
-		v := New(&mockKeyRetriever{}, UseGenesisFile("url", "domain", []byte(confFile)))
-
-		doc, err := v.Read("blah blah")
+		_, err := New(&mockKeyRetriever{}, UseGenesisFile("url", "domain", []byte(confFile)))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "error loading consortium genesis config")
-		require.Nil(t, doc)
 	})
 }
 
@@ -948,7 +965,8 @@ func TestVDRI_ValidateConsortium(t *testing.T) {
 	sigKey := ed25519SigningKey(t, keyJSON)
 
 	t.Run("success - no stakeholders to verify", func(t *testing.T) {
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		var confFile string
 
@@ -964,7 +982,6 @@ func TestVDRI_ValidateConsortium(t *testing.T) {
 			Previous: "",
 		}
 
-		var err error
 		confFile, err = signConfig(conf, []jose.SigningKey{*sigKey})
 		require.NoError(t, err)
 
@@ -973,7 +990,8 @@ func TestVDRI_ValidateConsortium(t *testing.T) {
 	})
 
 	t.Run("failure - consortium invalid", func(t *testing.T) {
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		confFile := `RU^&I*&*&OH`
 
@@ -982,13 +1000,14 @@ func TestVDRI_ValidateConsortium(t *testing.T) {
 		}))
 		defer consortiumServer.Close()
 
-		_, err := v.ValidateConsortium(consortiumServer.URL)
+		_, err = v.ValidateConsortium(consortiumServer.URL)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "consortium invalid")
 	})
 
 	t.Run("failure - stakeholders don't sign consortium config", func(t *testing.T) {
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		var consortiumFile, stakeholderFile, didConfFile string
 
@@ -1008,7 +1027,6 @@ func TestVDRI_ValidateConsortium(t *testing.T) {
 
 		consortium := dummyConsortium(consortiumServer.URL, stakeholderServer.URL)
 
-		var err error
 		consortiumFile, err = signConfig(consortium, []jose.SigningKey{*sigKey})
 		require.NoError(t, err)
 
@@ -1037,7 +1055,8 @@ func TestVDRI_ValidateConsortium(t *testing.T) {
 	})
 
 	t.Run("success - verify with one stakeholder", func(t *testing.T) {
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		var consortiumFile, stakeholderFile, didConfFile string
 
@@ -1057,8 +1076,6 @@ func TestVDRI_ValidateConsortium(t *testing.T) {
 			}
 		}))
 		defer stakeholderServer.Close()
-
-		var err error
 
 		consortium := dummyConsortium(consortiumServer.URL, stakeholderServer.URL)
 		consortiumFile, err = signConfig(consortium, []jose.SigningKey{*sigKey})
@@ -1087,7 +1104,8 @@ func TestVDRI_ValidateConsortium(t *testing.T) {
 	})
 
 	t.Run("failure - can't resolve stakeholder DID", func(t *testing.T) {
-		v := New(&mockKeyRetriever{})
+		v, err := New(&mockKeyRetriever{})
+		require.NoError(t, err)
 
 		var consortiumFile, stakeholderFile, didConfFile string
 
@@ -1104,8 +1122,6 @@ func TestVDRI_ValidateConsortium(t *testing.T) {
 			}
 		}))
 		defer stakeholderServer.Close()
-
-		var err error
 
 		consortium := dummyConsortium(consortiumServer.URL, stakeholderServer.URL)
 		consortiumFile, err = signConfig(consortium, []jose.SigningKey{*sigKey})
@@ -1184,7 +1200,8 @@ func TestVDRI_ValidateConsortium(t *testing.T) {
 
 		didConfFile = string(didConfBytes)
 
-		v := New(&mockKeyRetriever{}, EnableSignatureVerification(true))
+		v, err := New(&mockKeyRetriever{}, EnableSignatureVerification(true))
+		require.NoError(t, err)
 
 		v.configService = &mockconfig.MockConfigService{
 			GetConsortiumFunc: func(u string, d string) (*models.ConsortiumFileData, error) {
@@ -1274,7 +1291,8 @@ func Test_verifyStakeholder(t *testing.T) {
 				test.consortiumKey)
 			sfd := signedStakeholderFileData(t, dummyStakeholder(test.stakeholderDomain), test.stakeholderKey)
 
-			v := New(&mockKeyRetriever{})
+			v, err := New(&mockKeyRetriever{})
+			require.NoError(t, err)
 
 			v.getHTTPVDRI = httpVdriFunc(&did.DocResolution{DIDDocument: mockDoc}, nil)
 
@@ -1297,7 +1315,8 @@ func Test_verifyStakeholder(t *testing.T) {
 }
 
 func TestVDRI_Close(t *testing.T) {
-	v := New(&mockKeyRetriever{})
+	v, err := New(&mockKeyRetriever{})
+	require.NoError(t, err)
 	require.NoError(t, v.Close())
 }
 


### PR DESCRIPTION
fixes issue where genesis files weren't loaded before most VDR operations. Genesis files are now loaded on initialization.

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>