### PR TITLE
fix: Unable to retrieve certain keys - new CouchDB store implementation

### DIFF
--- a/component/newstorage/couchdb/go.mod
+++ b/component/newstorage/couchdb/go.mod
@@ -7,13 +7,14 @@ go 1.15
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
-	github.com/go-kivik/couchdb/v3 v3.2.5
+	github.com/go-kivik/couchdb/v3 v3.2.6
 	github.com/go-kivik/kivik/v3 v3.2.3
 	github.com/google/uuid v1.1.2
 	github.com/hyperledger/aries-framework-go v0.1.6-0.20210111225112-7200091513d3
 	github.com/hyperledger/aries-framework-go-ext/test/component/newstorage v0.0.0
 	github.com/ory/dockertest/v3 v3.6.3
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/net v0.0.0-20210119194325-5f4716e94777 // indirect
 )
 
 replace github.com/hyperledger/aries-framework-go-ext/test/component/newstorage => ../../../test/component/newstorage

--- a/component/newstorage/couchdb/go.sum
+++ b/component/newstorage/couchdb/go.sum
@@ -107,6 +107,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-kivik/couchdb/v3 v3.2.5 h1:ka08oPW1zLwLuJ4ZA2XxGB9Zfv35mJEKpK1IXpW9Qto=
 github.com/go-kivik/couchdb/v3 v3.2.5/go.mod h1:tUgf+ftTYkkNPyHskJW2O+6I1NUQvg7ucooVvhPQcxg=
+github.com/go-kivik/couchdb/v3 v3.2.6 h1:IzoAH5K7jsY1BFNibtdjAoPXRmm3rdQKJGjDMzXMvok=
+github.com/go-kivik/couchdb/v3 v3.2.6/go.mod h1:tUgf+ftTYkkNPyHskJW2O+6I1NUQvg7ucooVvhPQcxg=
 github.com/go-kivik/kivik/v3 v3.0.1/go.mod h1:7tmQDvkta/pcijpUjLMsQ9HJUELiKD5zm6jQ3Gb9cxE=
 github.com/go-kivik/kivik/v3 v3.2.0/go.mod h1:chqVuHKAU9j2C7qL0cAH2FCO26oL+0B4aIBeCRMnLa8=
 github.com/go-kivik/kivik/v3 v3.2.3 h1:ZFGR3hMDa+AUmPUCQxq4da3+3C4awdFQwdOtjLS+MxM=
@@ -414,6 +416,8 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20210119194325-5f4716e94777 h1:003p0dJM77cxMSyCPFphvZf/Y5/NXf5fzg6ufd1/Oew=
+golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -463,8 +467,10 @@ golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201211090839-8ad439b19e0f h1:QdHQnPce6K4XQewki9WNbG5KOROuDzqO3NaYjI1cXJ0=
 golang.org/x/sys v0.0.0-20201211090839-8ad439b19e0f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/component/newstorage/couchdb/store_test.go
+++ b/component/newstorage/couchdb/store_test.go
@@ -316,6 +316,26 @@ func TestStore_Put(t *testing.T) {
 	})
 }
 
+func TestStore_Get(t *testing.T) {
+	t.Run("Successfully get a value "+
+		"that was stored under a key containing special characters", func(t *testing.T) {
+		provider, err := NewProvider(couchDBURL, WithDBPrefix("prefix"))
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+
+		store, err := provider.OpenStore(randomStoreName())
+		require.NoError(t, err)
+		require.NotNil(t, store)
+
+		err = store.Put("https://example.com/", []byte("value"))
+		require.NoError(t, err)
+
+		value, err := store.Get("https://example.com/")
+		require.NoError(t, err)
+		require.Equal(t, string(value), "value")
+	})
+}
+
 func TestStore_GetTags(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		provider, err := NewProvider(couchDBURL, WithDBPrefix("prefix"))


### PR DESCRIPTION
The [bug](https://github.com/go-kivik/couchdb/issues/268) in the Kivik library has been fixed. This commit updates the import to the latest version.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>

closes #40