### PR TITLE
test: Update common tests and interface version

### DIFF
--- a/component/storage/couchdb/go.mod
+++ b/component/storage/couchdb/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/go-kivik/kivik/v3 v3.2.3
 	github.com/google/go-cmp v0.5.2 // indirect
 	github.com/google/uuid v1.2.0 // indirect
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210807121559-b41545a4f1e8
-	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210807121559-b41545a4f1e8
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210820175050-dcc7a225178d
+	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210820175050-dcc7a225178d
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/ory/dockertest/v3 v3.6.3
 	github.com/stretchr/testify v1.7.0

--- a/component/storage/couchdb/go.sum
+++ b/component/storage/couchdb/go.sum
@@ -40,11 +40,11 @@ github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/gopherjs/gopherjs v0.0.0-20180825215210-0210a2f0f73c/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 h1:l5lAOZEym3oK3SQ2HBHWsJUfbNBiTXJDeW2QDxw9AQ0=
 github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210806210220-65863dbe349a/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210807121559-b41545a4f1e8 h1:gkZIZfNZg9fBViWslzcjSmQBjjh73BH2WFoEl7aFcdw=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210807121559-b41545a4f1e8/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210807121559-b41545a4f1e8 h1:9nd+4NsvBSjH3zIaM0B3Zr5kpaQHMmFFqzgVAE2fG7o=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210807121559-b41545a4f1e8/go.mod h1:3idbNcBl2wdRaETayzpY95KK5SfSzwXb5uqLW/Ldh0g=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210818133831-4e22573c126d/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210820175050-dcc7a225178d h1:0JfPT4ORTdFMQknng3TiA2G/YY80+AMmty/47K7z4Rw=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210820175050-dcc7a225178d/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210820175050-dcc7a225178d h1:6n55F8lsCR2OGGZ+3RB2ppXkdmtVaoTV7MoTvpFRyTg=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210820175050-dcc7a225178d/go.mod h1:7jEZdg455syX4f+ozLgwhYfIuiEQ/TgdIoOyALMwPG0=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/component/storage/couchdb/store.go
+++ b/component/storage/couchdb/store.go
@@ -262,8 +262,9 @@ func (p *Provider) OpenStore(name string) (storage.Store, error) {
 }
 
 // SetStoreConfig sets the configuration on a store.
-// Indexes are created based on the tag names in config. This allows the store.Query method to operate faster, and is
-// required to
+// Indexes are created based on the tag names in config. This allows the store.Query method to operate faster with
+// large datasets. If you want to do queries with sorts, then you must ensure the tag you're sorting on is indexed,
+// otherwise the query will fail.
 // Existing tag names/indexes in the store that are not in the config passed in here will be removed.
 // The store must be created prior to calling this method.
 // If duplicate tags are provided, then CouchDB will ignore them.
@@ -695,9 +696,9 @@ func (s *store) GetBulk(keys ...string) ([][]byte, error) {
 // If TagValue is not provided, then all data associated with the TagName will be returned.
 // For now, expression can only be a single tag Name + Value pair.
 // If no options are provided, then defaults will be used.
-// For improved performance, ensure that the tag name you are querying is included in the store config, as this
-// will ensure that it's indexed in CouchDB.
-// TODO (#44) Should we make the store config mandatory?
+// If sorting is used, then the tag used for sorting must be indexed.
+// For improved performance with large datasets, ensure that the tag name you are querying is included in the store
+// config, as this will ensure that it's indexed in CouchDB.
 func (s *store) Query(expression string, options ...storage.QueryOption) (storage.Iterator, error) {
 	if expression == "" {
 		return &couchDBResultsIterator{}, errInvalidQueryExpressionFormat

--- a/component/storage/couchdb/store_test.go
+++ b/component/storage/couchdb/store_test.go
@@ -113,13 +113,13 @@ func TestCommon(t *testing.T) {
 				prov, err := NewProvider(couchDBURL)
 				require.NoError(t, err)
 
-				commontest.TestAll(t, prov, commontest.WithIteratorTotalItemCountTests())
+				runCommonTests(t, prov)
 			})
 			t.Run("With custom logger option", func(t *testing.T) {
 				prov, err := NewProvider(couchDBURL, WithLogger(&mockLogger{}))
 				require.NoError(t, err)
 
-				commontest.TestAll(t, prov, commontest.WithIteratorTotalItemCountTests())
+				runCommonTests(t, prov)
 			})
 		})
 		t.Run("With Max Document Conflict Retries option set to 2", func(t *testing.T) {
@@ -127,14 +127,14 @@ func TestCommon(t *testing.T) {
 				prov, err := NewProvider(couchDBURL, WithMaxDocumentConflictRetries(2))
 				require.NoError(t, err)
 
-				commontest.TestAll(t, prov, commontest.WithIteratorTotalItemCountTests())
+				runCommonTests(t, prov)
 			})
 			t.Run("With custom logger", func(t *testing.T) {
 				prov, err := NewProvider(couchDBURL, WithMaxDocumentConflictRetries(2),
 					WithLogger(&mockLogger{}))
 				require.NoError(t, err)
 
-				commontest.TestAll(t, prov, commontest.WithIteratorTotalItemCountTests())
+				runCommonTests(t, prov)
 			})
 		})
 	})
@@ -144,13 +144,13 @@ func TestCommon(t *testing.T) {
 				prov, err := NewProvider(couchDBURL, WithDBPrefix("test-prefix"))
 				require.NoError(t, err)
 
-				commontest.TestAll(t, prov, commontest.WithIteratorTotalItemCountTests())
+				runCommonTests(t, prov)
 			})
 			t.Run("With custom logger", func(t *testing.T) {
 				prov, err := NewProvider(couchDBURL, WithDBPrefix("test-prefix"), WithLogger(&mockLogger{}))
 				require.NoError(t, err)
 
-				commontest.TestAll(t, prov, commontest.WithIteratorTotalItemCountTests())
+				runCommonTests(t, prov)
 			})
 		})
 		t.Run("With max document conflict retries option set to 2", func(t *testing.T) {
@@ -159,17 +159,24 @@ func TestCommon(t *testing.T) {
 					WithMaxDocumentConflictRetries(2))
 				require.NoError(t, err)
 
-				commontest.TestAll(t, prov, commontest.WithIteratorTotalItemCountTests())
+				runCommonTests(t, prov)
 			})
 			t.Run("With custom logger", func(t *testing.T) {
 				prov, err := NewProvider(couchDBURL, WithDBPrefix("test-prefix"),
 					WithMaxDocumentConflictRetries(2), WithLogger(&mockLogger{}))
 				require.NoError(t, err)
 
-				commontest.TestAll(t, prov, commontest.WithIteratorTotalItemCountTests())
+				runCommonTests(t, prov)
 			})
 		})
 	})
+}
+
+func runCommonTests(t *testing.T, prov *Provider) {
+	t.Helper()
+
+	commontest.TestAll(t, prov, commontest.SkipSortTests(true),
+		commontest.SkipIteratorTotalItemTests(true))
 }
 
 func TestNewProvider(t *testing.T) {

--- a/component/storage/mongodb/go.mod
+++ b/component/storage/mongodb/go.mod
@@ -8,8 +8,8 @@ go 1.15
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.1.1
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210811170524-6bb150dd7968
-	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210811170524-6bb150dd7968
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210820175050-dcc7a225178d
+	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210820175050-dcc7a225178d
 	github.com/ory/dockertest/v3 v3.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1

--- a/component/storage/mongodb/go.sum
+++ b/component/storage/mongodb/go.sum
@@ -63,11 +63,11 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaU
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210806210220-65863dbe349a/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210811170524-6bb150dd7968 h1:ictNsPCSjS12B2OgAx2nDZmxvUie9VIfvsPilZusoxY=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210811170524-6bb150dd7968/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210811170524-6bb150dd7968 h1:HkR9PUD5DSK8tPofyuwFXL7EVyvTo6cg3cy8eORs03E=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210811170524-6bb150dd7968/go.mod h1:3idbNcBl2wdRaETayzpY95KK5SfSzwXb5uqLW/Ldh0g=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210818133831-4e22573c126d/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210820175050-dcc7a225178d h1:0JfPT4ORTdFMQknng3TiA2G/YY80+AMmty/47K7z4Rw=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210820175050-dcc7a225178d/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210820175050-dcc7a225178d h1:6n55F8lsCR2OGGZ+3RB2ppXkdmtVaoTV7MoTvpFRyTg=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210820175050-dcc7a225178d/go.mod h1:7jEZdg455syX4f+ozLgwhYfIuiEQ/TgdIoOyALMwPG0=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/component/storage/mongodb/store_test.go
+++ b/component/storage/mongodb/store_test.go
@@ -190,7 +190,7 @@ func doAllTests(t *testing.T, connString string) {
 		}))
 	require.NoError(t, err)
 
-	commontest.TestAll(t, provider, commontest.WithIteratorTotalItemCountTests())
+	commontest.TestAll(t, provider)
 	testCloseProviderTwice(t, connString)
 
 	testMultipleProvidersSettingSameStoreConfigurationAtTheSameTime(t, connString)

--- a/component/storage/mysql/go.mod
+++ b/component/storage/mysql/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/google/go-cmp v0.5.4 // indirect
 	github.com/google/uuid v1.2.0
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210807121559-b41545a4f1e8
-	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210807121559-b41545a4f1e8
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210820175050-dcc7a225178d
+	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210820175050-dcc7a225178d
 	github.com/kr/text v0.2.0 // indirect
 	github.com/lib/pq v1.9.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect

--- a/component/storage/mysql/go.sum
+++ b/component/storage/mysql/go.sum
@@ -35,11 +35,11 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210806210220-65863dbe349a/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210807121559-b41545a4f1e8 h1:gkZIZfNZg9fBViWslzcjSmQBjjh73BH2WFoEl7aFcdw=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210807121559-b41545a4f1e8/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210807121559-b41545a4f1e8 h1:9nd+4NsvBSjH3zIaM0B3Zr5kpaQHMmFFqzgVAE2fG7o=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210807121559-b41545a4f1e8/go.mod h1:3idbNcBl2wdRaETayzpY95KK5SfSzwXb5uqLW/Ldh0g=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210818133831-4e22573c126d/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210820175050-dcc7a225178d h1:0JfPT4ORTdFMQknng3TiA2G/YY80+AMmty/47K7z4Rw=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210820175050-dcc7a225178d/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210820175050-dcc7a225178d h1:6n55F8lsCR2OGGZ+3RB2ppXkdmtVaoTV7MoTvpFRyTg=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210820175050-dcc7a225178d/go.mod h1:7jEZdg455syX4f+ozLgwhYfIuiEQ/TgdIoOyALMwPG0=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=


### PR DESCRIPTION
- Latest common storage tests commit includes new tests.
- Updated MySQL implementation to pass them. The MySQL implementation also now defers creating a tag map until needed. It also now doesn't require SetStoreConfig in order to do queries in order to keep in line with the latest interface documentation.
- Updated some documentation for the CouchDB implementation.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>