### PR TITLE
feat: GetStoreConfig can now be used to check for underlying database

### DIFF
--- a/component/storage/mongodb/go.mod
+++ b/component/storage/mongodb/go.mod
@@ -8,8 +8,8 @@ go 1.15
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.1.1
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210820175050-dcc7a225178d
-	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210820175050-dcc7a225178d
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20210820204349-ab3143ab760b
+	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210820204349-ab3143ab760b
 	github.com/ory/dockertest/v3 v3.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1

--- a/component/storage/mongodb/go.sum
+++ b/component/storage/mongodb/go.sum
@@ -63,11 +63,11 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaU
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210818133831-4e22573c126d/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210820175050-dcc7a225178d h1:0JfPT4ORTdFMQknng3TiA2G/YY80+AMmty/47K7z4Rw=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20210820175050-dcc7a225178d/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210820175050-dcc7a225178d h1:6n55F8lsCR2OGGZ+3RB2ppXkdmtVaoTV7MoTvpFRyTg=
-github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210820175050-dcc7a225178d/go.mod h1:7jEZdg455syX4f+ozLgwhYfIuiEQ/TgdIoOyALMwPG0=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210820153043-8b6f36d10ab9/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210820204349-ab3143ab760b h1:Y1CYskAOTp1UuPUtz8g+RZ88bO8JzY4m6YJ5K3+lb/4=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20210820204349-ab3143ab760b/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210820204349-ab3143ab760b h1:sGKuQ/2fZhfXMIuO2JZXnDmZ1LG62dkZfvpHSdM8N+Y=
+github.com/hyperledger/aries-framework-go/test/component v0.0.0-20210820204349-ab3143ab760b/go.mod h1:qVBfLn+oRVIidRYw/HxZmj2COETUZR5lFPfiYH4AMr0=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/component/storage/mysql/store.go
+++ b/component/storage/mysql/store.go
@@ -193,6 +193,7 @@ func (p *Provider) SetStoreConfig(name string, config storage.StoreConfiguration
 }
 
 // GetStoreConfig returns the store's configuration.
+// TODO (#167): Check for underlying database's existence instead of looking at in-memory stores.
 func (p *Provider) GetStoreConfig(name string) (storage.StoreConfiguration, error) {
 	name = strings.ToLower(name)
 


### PR DESCRIPTION
Update the MongoDB implementation of GetStoreConfig to check for the underlying database's existence instead of looking at the in-memory store objects, per the storage interface documentation.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>