### PR TITLE
feat: use round robin for orb domains

### DIFF
--- a/component/vdr/orb/lb/roundrobin.go
+++ b/component/vdr/orb/lb/roundrobin.go
@@ -1,0 +1,39 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package lb implement load balancer
+//
+package lb
+
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+
+	"github.com/hyperledger/aries-framework-go-ext/component/vdr/orb/util/concurrent/rollingcounter"
+)
+
+var logger = log.New("aries-framework-ext/vdr/orb") //nolint: gochecknoglobals
+
+// RoundRobin implements a round-robin load-balance policy.
+type RoundRobin struct {
+	counter *rollingcounter.Counter
+}
+
+// NewRoundRobin returns a new RoundRobin load-balance policy.
+func NewRoundRobin() *RoundRobin {
+	return &RoundRobin{
+		counter: rollingcounter.New(),
+	}
+}
+
+// Choose chooses from the list of domains in round-robin fashion.
+func (rb *RoundRobin) Choose(domains []string) (string, error) {
+	if len(domains) == 0 {
+		logger.Warnf("No domains to choose from!")
+
+		return "", nil
+	}
+
+	return domains[rb.counter.Next(len(domains))], nil
+}

--- a/component/vdr/orb/lb/roundrobin_test.go
+++ b/component/vdr/orb/lb/roundrobin_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package lb_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go-ext/component/vdr/orb/lb"
+)
+
+func TestRoundRobin(t *testing.T) {
+	lbp := lb.NewRoundRobin()
+
+	// Test with an empty set of domains
+	domain, err := lbp.Choose([]string{})
+	require.NoError(t, err)
+	require.Empty(t, domain)
+
+	domains := newMockDomins(10)
+
+	lastIndexChosen := -1
+
+	// Invoke a number of times and make sure it chooses each one consecutively
+	for i := 0; i < len(domains); i++ {
+		domain, err := lbp.Choose(domains)
+		require.NoError(t, err)
+
+		chosenIndex := findIndex(domains, domain)
+
+		if lastIndexChosen >= 0 { //nolint: nestif
+			if lastIndexChosen == (len(domains) - 1) {
+				if chosenIndex != 0 {
+					t.Fatalf("expecting chosen index to be 0 but got index %d", chosenIndex)
+				}
+			} else {
+				if chosenIndex != lastIndexChosen+1 {
+					t.Fatalf("expecting chosen index to be %d but got index %d", lastIndexChosen+1, chosenIndex)
+				}
+			}
+		}
+
+		lastIndexChosen = chosenIndex
+	}
+}
+
+func findIndex(domains []string, domain string) int {
+	for i, d := range domains {
+		if domain == d {
+			return i
+		}
+	}
+
+	panic("domain does not exist in list of domains")
+}
+
+func newMockDomins(numDomains int) []string {
+	var domains []string
+	for i := 0; i < numDomains; i++ {
+		domains = append(domains, fmt.Sprintf("domain_%d", i))
+	}
+
+	return domains
+}

--- a/component/vdr/orb/util/concurrent/rollingcounter/rollingcounter.go
+++ b/component/vdr/orb/util/concurrent/rollingcounter/rollingcounter.go
@@ -1,0 +1,61 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package rollingcounter implement rolling counter
+//
+package rollingcounter
+
+import (
+	"math/rand"
+	"sync/atomic"
+
+	"github.com/hyperledger/aries-framework-go/pkg/common/log"
+)
+
+var logger = log.New("aries-framework-ext/vdr/orb") //nolint: gochecknoglobals
+
+// Counter is a rolling counter that increments an index up to a maximum value. If the counter reaches
+// the maximum then the counter resets to 0. A single counter instance may be used by multiple Go routines.
+type Counter struct {
+	index int32
+}
+
+// New returns a new rolling counter.
+func New() *Counter {
+	return &Counter{index: -1}
+}
+
+// Next increments the counter. If the counter reaches n then
+// the counter is reset to 0. Note: n must be greater than 0 or else
+// a panic will result.
+func (c *Counter) Next(n int) int {
+	if n <= 0 {
+		panic("n must be greater than 0")
+	}
+
+	for {
+		current := atomic.LoadInt32(&c.index)
+		logger.Debugf("Current index: %d", current)
+
+		i := int(current)
+		if i == -1 {
+			// Choose a random index the first time
+			i = rand.Intn(n) //nolint: gosec
+		} else {
+			i++
+			if i >= n {
+				i = 0
+			}
+		}
+
+		if atomic.CompareAndSwapInt32(&c.index, current, int32(i)) {
+			logger.Debugf("Set the counter to %d", i)
+
+			return i
+		}
+
+		logger.Debugf("Another thread has already incremented the counter. Trying again...")
+	}
+}

--- a/component/vdr/orb/util/concurrent/rollingcounter/rollingcounter_test.go
+++ b/component/vdr/orb/util/concurrent/rollingcounter/rollingcounter_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package rollingcounter_test
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/aries-framework-go-ext/component/vdr/orb/util/concurrent/rollingcounter"
+)
+
+func TestCounter(t *testing.T) {
+	t.Run("Basic", func(t *testing.T) {
+		counter := rollingcounter.New()
+
+		n := 10
+		i := counter.Next(n)
+		require.True(t, i < n)
+
+		j := i
+		i = counter.Next(n)
+		require.True(t, i != j)
+
+		n = 2
+		i = counter.Next(n)
+		require.True(t, i < n)
+	})
+
+	t.Run("Concurrent", func(t *testing.T) {
+		counter := rollingcounter.New()
+
+		concurrency := 10
+		iterations := 100
+		maxN := 10
+
+		var wg sync.WaitGroup
+		wg.Add(concurrency)
+		defer wg.Wait()
+
+		for g := 0; g < concurrency; g++ {
+			go func() {
+				defer wg.Done()
+				n := rand.Intn(maxN) + 1 //nolint: gosec
+				for j := 0; j < iterations; j++ {
+					i := counter.Next(n)
+					require.True(t, i < n, "index should be less than %d but was %d", n, i)
+				}
+			}()
+		}
+	})
+}

--- a/component/vdr/orb/vdr_test.go
+++ b/component/vdr/orb/vdr_test.go
@@ -366,8 +366,7 @@ func TestVDRI_Create(t *testing.T) {
 		}, vdrapi.WithOption(OperationEndpointsOpt, []string{"url"}),
 			vdrapi.WithOption(UpdatePublicKeyOpt, []byte{}),
 			vdrapi.WithOption(RecoveryPublicKeyOpt, []byte{}))
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "anchorOrigin opt is empty")
+		require.NoError(t, err)
 	})
 
 	t.Run("test anchor origin opt is not string", func(t *testing.T) {
@@ -759,8 +758,7 @@ func TestVDRI_Recover(t *testing.T) {
 			},
 			Authentication: []did.Verification{*ver},
 		}, vdrapi.WithOption(ResolutionEndpointsOpt, []string{cServ.URL}),
-			vdrapi.WithOption(RecoverOpt, true),
-			vdrapi.WithOption(AnchorOriginOpt, "origin.com"))
+			vdrapi.WithOption(RecoverOpt, true))
 		require.NoError(t, err)
 	})
 
@@ -802,23 +800,6 @@ func TestVDRI_Recover(t *testing.T) {
 			vdrapi.WithOption(AnchorOriginOpt, "origin.com"))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "vm relationship 0 not supported")
-	})
-
-	t.Run("test anchor origin is empty", func(t *testing.T) {
-		cServ := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-type", "application/did+ld+json")
-			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, validDocResolution)
-		}))
-		defer cServ.Close()
-
-		v, err := New(nil)
-		require.NoError(t, err)
-
-		err = v.Update(&did.Doc{}, vdrapi.WithOption(ResolutionEndpointsOpt, []string{cServ.URL}),
-			vdrapi.WithOption(RecoverOpt, true))
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "anchorOrigin opt is empty")
 	})
 
 	t.Run("test anchor origin is not string", func(t *testing.T) {

--- a/test/bdd/vdr/orb/pkg/vdr/vdr_steps.go
+++ b/test/bdd/vdr/orb/pkg/vdr/vdr_steps.go
@@ -42,7 +42,6 @@ const (
 	bls12381G2KeyType = "Bls12381G2"
 	// Ed25519KeyType ed25519 key type.
 	Ed25519KeyType = "Ed25519"
-	origin         = "https://testnet.orb.local"
 	jsonWebKey2020 = "JsonWebKey2020"
 )
 
@@ -171,7 +170,7 @@ func (e *Steps) recoverDID(keyType, signatureSuite string) error {
 	didDoc := e.createdDoc.DIDDocument
 
 	if err := e.vdr.Update(didDoc,
-		vdrapi.WithOption(orb.RecoverOpt, true), vdrapi.WithOption(orb.AnchorOriginOpt, origin)); err != nil {
+		vdrapi.WithOption(orb.RecoverOpt, true)); err != nil {
 		return err
 	}
 
@@ -239,7 +238,7 @@ func (e *Steps) create(keyType, signatureSuite, resolveDID string) error {
 		retry = nil
 	}
 
-	if err := e.createDID(keyType, signatureSuite, origin, retry); err != nil {
+	if err := e.createDID(keyType, signatureSuite, "", retry); err != nil {
 		return err
 	}
 
@@ -288,9 +287,12 @@ func (e *Steps) createDID(keyType, signatureSuite, origin string, retry *orb.Res
 		opts = append(opts, vdrapi.WithOption(orb.CheckDIDAnchored, retry))
 	}
 
+	if origin != "" {
+		opts = append(opts, vdrapi.WithOption(orb.AnchorOriginOpt, origin))
+	}
+
 	opts = append(opts, vdrapi.WithOption(orb.RecoveryPublicKeyOpt, recoveryKey),
-		vdrapi.WithOption(orb.UpdatePublicKeyOpt, updateKey),
-		vdrapi.WithOption(orb.AnchorOriginOpt, origin))
+		vdrapi.WithOption(orb.UpdatePublicKeyOpt, updateKey))
 
 	createdDocResolution, err := e.vdr.Create(didDoc, opts...)
 	if err != nil {


### PR DESCRIPTION
- Configure a set of domains to hit
- Use a round-robin/random algorithm to choose a domain
- Use the same domain as the anchor origin

Signed-off-by: Firas Qutishat <firas.qutishat@securekey.com>