### PR TITLE
feat: Wrap MongoDB duplicate key error

### DIFF
--- a/component/storage/mongodb/go.mod
+++ b/component/storage/mongodb/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/google/uuid v1.1.2
-	github.com/hyperledger/aries-framework-go/spi v0.0.0-20211204013109-366f6ef74861
+	github.com/hyperledger/aries-framework-go/spi v0.0.0-20211206182816-9cdcbcd09dc2
 	github.com/hyperledger/aries-framework-go/test/component v0.0.0-20211204013109-366f6ef74861
 	github.com/ory/dockertest/v3 v3.7.0
 	github.com/pkg/errors v0.9.1

--- a/component/storage/mongodb/go.sum
+++ b/component/storage/mongodb/go.sum
@@ -39,8 +39,8 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20211203210130-e927c9ed581a/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20211204013109-366f6ef74861 h1:ELSlVNPE0sc/+J+grRCZiZLyrMpbqu/iMsWWZ7XpDtY=
-github.com/hyperledger/aries-framework-go/spi v0.0.0-20211204013109-366f6ef74861/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20211206182816-9cdcbcd09dc2 h1:gip43O6a6NW9hSGgb0fJNlxVLq6m+12GAMIzhuQuxjk=
+github.com/hyperledger/aries-framework-go/spi v0.0.0-20211206182816-9cdcbcd09dc2/go.mod h1:dBYKKD8U8U9o0g5BdNFFaRtjt9KTkiAYfQt+TTp+w1o=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20211204013109-366f6ef74861 h1:E2S0EJauFrLlEdgP/3u9cmUipzIKY+e8DvazfttJb6M=
 github.com/hyperledger/aries-framework-go/test/component v0.0.0-20211204013109-366f6ef74861/go.mod h1:UPbljMgUwdph/L36m8LrFxnZ4UP32pXeJ/GfluusI3c=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=

--- a/component/storage/mongodb/store_test.go
+++ b/component/storage/mongodb/store_test.go
@@ -1288,16 +1288,11 @@ func testBatchIsNewKeyError(t *testing.T, connString string) {
 
 	err = store.Batch(operations)
 
-	expectedErrMsgPrefix := "failed to perform batch operations after 4 attempts due to a " +
-		"duplicate key error. It appears that the IsNewKey optimization flag has been set on one or " +
-		"more put operations. This error indicates that at least one of the keys in those put operations " +
-		"already exists. The IsNewKey flag can only be used if the key does not exist. If the key does " +
-		"exist (or may exist), set it to false instead. Alternatively, if using MongoDB 4.0.0, then this " +
-		"may be a transient error that sometimes happens when there are multiple calls to the database at " +
-		"the same time that do batch operations under the same key(s). If this error is due to the transient " +
-		"error, then this storage provider may need to be started with a higher max retry limit and/or higher " +
-		"time between retries. Underlying error message: bulk write exception: write errors: [E11000 duplicate" +
-		" key error"
+	expectedErrMsgPrefix := "failed to perform batch operations after 4 attempts: duplicate key. Either the " +
+		"IsNewKey optimization flag has been set to true for a key that already exists in the database, or, if " +
+		"using MongoDB 4.0.0, then this may be a transient error due to another call storing data under the same " +
+		"key at the same time. Underlying error message: bulk write exception: write errors: [E11000 duplicate key " +
+		"error"
 
 	gotExpectedError := strings.HasPrefix(err.Error(), expectedErrMsgPrefix)
 


### PR DESCRIPTION
- Wrapped the error that can happen when using the IsNewKey optimization flag with a key that already exists with a special error value from the storage interface
- Also shortened the error text overall to be more succinct.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>