### PR TITLE
fix: Longform VDR method should not include did prefix

### DIFF
--- a/component/vdr/longform/vdr.go
+++ b/component/vdr/longform/vdr.go
@@ -35,7 +35,7 @@ const (
 	RecoveryPublicKeyOpt = "recoveryPublicKey"
 
 	sha2_256         = 18
-	defaultDIDMethod = "did:ion"
+	defaultDIDMethod = "ion"
 )
 
 type sidetreeClient interface {
@@ -76,7 +76,7 @@ func New(opts ...Option) (*VDR, error) {
 
 	var err error
 
-	v.sidetreeDocHandler, err = dochandler.New(v.method)
+	v.sidetreeDocHandler, err = dochandler.New(fmt.Sprintf("did:%s", v.method))
 	if err != nil {
 		return nil, err
 	}

--- a/component/vdr/longform/vdr_test.go
+++ b/component/vdr/longform/vdr_test.go
@@ -48,7 +48,7 @@ func TestVDRI_Accept(t *testing.T) {
 	t.Run("test return false", func(t *testing.T) {
 		v, err := New()
 		require.NoError(t, err)
-		require.False(t, v.Accept("did:different"))
+		require.False(t, v.Accept("different"))
 	})
 }
 
@@ -67,10 +67,10 @@ func TestVDRI_Options(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
 		docLoader := createTestDocLoader(t)
 
-		v, err := New(WithDIDMethod("did:different"), WithDocumentLoader(docLoader))
+		v, err := New(WithDIDMethod("different"), WithDocumentLoader(docLoader))
 		require.NoError(t, err)
 		require.False(t, v.Accept(defaultDIDMethod))
-		require.True(t, v.Accept("did:different"))
+		require.True(t, v.Accept("different"))
 
 		err = v.Close()
 		require.NoError(t, err)
@@ -82,7 +82,7 @@ func TestVDRI_Read(t *testing.T) {
 		v, err := New()
 		require.NoError(t, err)
 
-		longFormDID := fmt.Sprintf("%s:%s:%s", defaultDIDMethod, didSuffix, requestJCS)
+		longFormDID := fmt.Sprintf("did:%s:%s:%s", defaultDIDMethod, didSuffix, requestJCS)
 
 		docResolution, err := v.Read(longFormDID)
 		require.NoError(t, err)
@@ -104,7 +104,7 @@ func TestVDRI_Read(t *testing.T) {
 		require.Equal(t, 1, len(didDoc.CapabilityDelegation))
 		require.Equal(t, 1, len(didDoc.KeyAgreement))
 
-		require.Equal(t, docResolution.DocumentMetadata.EquivalentID[0], fmt.Sprintf("%s:%s", defaultDIDMethod, didSuffix))
+		require.Equal(t, docResolution.DocumentMetadata.EquivalentID[0], fmt.Sprintf("did:%s:%s", defaultDIDMethod, didSuffix))
 	})
 
 	t.Run("test sidetree document handler error", func(t *testing.T) {
@@ -113,7 +113,7 @@ func TestVDRI_Read(t *testing.T) {
 
 		v.sidetreeDocHandler = &mockDocHandler{Err: fmt.Errorf("document handler error")}
 
-		longFormDID := fmt.Sprintf("%s:%s:%s", defaultDIDMethod, didSuffix, requestJCS)
+		longFormDID := fmt.Sprintf("did:%s:%s:%s", defaultDIDMethod, didSuffix, requestJCS)
 
 		docResolution, err := v.Read(longFormDID)
 		require.Error(t, err)
@@ -127,7 +127,7 @@ func TestVDRI_Read(t *testing.T) {
 
 		v.sidetreeDocHandler = &mockDocHandler{ResolutionResult: &document.ResolutionResult{}}
 
-		longFormDID := fmt.Sprintf("%s:%s:%s", defaultDIDMethod, didSuffix, requestJCS)
+		longFormDID := fmt.Sprintf("did:%s:%s:%s", defaultDIDMethod, didSuffix, requestJCS)
 
 		docResolution, err := v.Read(longFormDID)
 		require.Error(t, err)


### PR DESCRIPTION
Longform VDR method should not include did prefix

Closes #300

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>